### PR TITLE
Fixing account managment now

### DIFF
--- a/InstagramProject/Models/AccountManager.cs
+++ b/InstagramProject/Models/AccountManager.cs
@@ -78,39 +78,16 @@ namespace InstagramProject.Models
 
             while (true)
             {
-              
-                UserName = userName,
-                Email = email,
-                Password = password
-            };
 
-            _context.Users.Add(newUser);
-            _context.SaveChanges();
+                    newUsername = AnsiConsole.Ask<string>("Enter your [green]new username[/]:");
 
-            Console.WriteLine("User account created successfully!");
-        }
-        public void ChangeUserDetail(string fieldType, string newValue)
-        {
-            if (_loggedInUser != null)
-            {
-                var user = _context.Users.FirstOrDefault(u => u.UserId == _loggedInUser.UserId);
-                if (user != null)
-                {
-                    switch (fieldType)
+                    if (CheckDuplicate(newUsername))
                     {
-                        case "Username":
-                            user.UserName = newValue;
-                            break;
-                        case "Password":
-                            user.Password = newValue;
-                            break;
-                        case "Email":
-                            user.Email = newValue;
-                            break;
                     }
-                    _context.SaveChanges();
-                    AnsiConsole.MarkupLine($"[bold green]{fieldType} updated successfully![/]");
-                }
+                    else
+                    {
+                        break;
+                    }
             }
 
             while (true)
@@ -162,14 +139,14 @@ namespace InstagramProject.Models
 
                 switch (fieldType)
                 {
-                    case "username":
+                    case "Username":
                         if (CheckDuplicate(newValue))
                         {
                             return;
                         }
                         user.UserName = newValue;
                         break;
-                    case "password":
+                    case "Password":
                         if (ValidatePasswordStrength(newValue))
                         {
                             user.Password = newValue;
@@ -180,7 +157,7 @@ namespace InstagramProject.Models
                             return;
                         }
                         break;
-                    case "email":
+                    case "Email":
                         if (CheckDuplicate(newValue))
                         {
                             return;
@@ -250,116 +227,5 @@ namespace InstagramProject.Models
             return true;
         }
 
-
-        //public void CreateAccount()
-        //{
-        //    string userName = GetUserName();
-        //    Console.WriteLine($"Username '{userName}' accepted!");
-
-        //    string email = GetEmail();
-        //    Console.WriteLine($"Email '{email}' accepted!");
-
-        //    string password = GetPassword();
-        //    Console.WriteLine("Password accepted!");
-
-        //    User newUser = new User
-        //    {
-        //        UserName = userName,
-        //        Email = email,
-        //        Password = password
-        //    };
-
-        //    _context.Users.Add(newUser);
-        //    _context.SaveChanges();
-
-        //    Console.WriteLine("User account created successfully!");
-        //}
-
-        //public string GetUserName()
-        //{
-        //    return ValidateNotEmptyAndUnique(
-        //        "Enter a username:",
-        //        "Username cannot be empty. Please try again.",
-        //        "Username already exists. Please choose another one.",
-        //        user => user.UserName!
-        //    );
-        //}
-
-        //public string GetEmail()
-        //{
-        //    return ValidateNotEmptyAndUnique(
-        //        "Enter a email:",
-        //        "Email cannot be empty. Please try again.",
-        //        "Email already exists. Please choose another one.",
-        //        user => user.Email!
-        //    );
-        //}
-
-        //public string GetPassword()
-        //{
-        //    while (true)
-        //    {
-        //        Console.Write("Enter a password: ");
-        //        string password = Console.ReadLine()!;
-
-        //        if (!ValidatePasswordStrength(password))
-        //        {
-        //            Console.WriteLine("Please enter a stronger password.");
-        //        }
-        //        else
-        //        {
-        //            Console.WriteLine("Password is strong enough.");
-        //        return password;
-        //        }
-        //    }
-        //}
-        //public string ValidateNotEmptyAndUnique(string inputPrompt, string emptyErrorMessage, string duplicateErrorMessage, Func<User, string> fieldSelector)
-        //{
-        //    while (true)
-        //    {
-        //        Console.WriteLine(inputPrompt);
-        //        string userInput = Console.ReadLine()!;
-
-        //        if (string.IsNullOrEmpty(userInput))
-        //        {
-        //            Console.WriteLine(emptyErrorMessage);
-        //        }
-        //        else
-        //        {
-        //            bool exists = _context.Users
-        //                                  .Select(fieldSelector)
-        //                                  .ToList()
-        //                                  .Contains(userInput);
-
-        //            if (exists)
-        //            {
-        //                Console.WriteLine(duplicateErrorMessage);
-        //            }
-        //            else
-        //            {
-        //                return userInput;
-        //            }
-        //        }
-        //    }
-        //}
-
-
-        //public string ValidateNotEmpty(string inputPrompt, string emptyErrorMessage)
-        //{
-        //    while (true)
-        //    {
-        //        Console.WriteLine(inputPrompt);
-        //        string userInput = Console.ReadLine()!;
-
-        //        if (string.IsNullOrEmpty(userInput))
-        //        {
-        //            Console.WriteLine(emptyErrorMessage);
-        //        }
-        //        else
-        //        {
-        //            return userInput;
-        //        }
-        //    }
-        //}
     }
 }

--- a/InstagramProject/Models/InstagramContext.cs
+++ b/InstagramProject/Models/InstagramContext.cs
@@ -27,7 +27,7 @@ public partial class InstagramContext : DbContext
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
 #warning To protect potentially sensitive information in your connection string, you should move it out of source code. You can avoid scaffolding the connection string by using the Name= syntax to read it from configuration - see https://go.microsoft.com/fwlink/?linkid=2131148. For more guidance on storing connection strings, see https://go.microsoft.com/fwlink/?LinkId=723263.
-        => optionsBuilder.UseSqlServer("Server=DESKTOP-7HK3IV2\\SQLEXPRESS;Database=Instagram;Trusted_Connection=True;TrustServerCertificate=True;");
+        => optionsBuilder.UseSqlServer("Server=Hanan\\SQLEXPRESS;Database=Instagram;Trusted_Connection=True;TrustServerCertificate=True;");
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {


### PR DESCRIPTION
Fixing redundancy that appears with a conflict.  
Deleting the comment that was at the bottom of `AccountManager`, and changing the first letters of `email`, `password`, and `user` to capital letters.